### PR TITLE
Updated dependencies versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ ethers-rs middleware and signer for Fireblocks' APIs
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ethers-core = { version = "0.5.1"}
-ethers-signers = { version = "0.5.1" }
-ethers-providers = { version = "0.5.1" }
+ethers-core = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-signers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
+ethers-providers = { git = "https://github.com/gakonst/ethers-rs", default-features = false }
 
 serde_json = "1.0.60"
 serde = "1.0.118"


### PR DESCRIPTION
For compatibility with foundry (^0.5.1 doesn't cover latest version 1.0.2)