### PR TITLE
Allow use of SDK with sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,11 @@ use std::convert::TryFrom;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let wallet_id = "1"; // Our wallet id
     let chain_id = 3; // Ropsten
     let cfg = Config::new(
         &std::env::var("FIREBLOCKS_API_SECRET_PATH").expect("fireblocks secret not set"),
         &std::env::var("FIREBLOCKS_API_KEY").expect("fireblocks api key not set"),
-        wallet_id,
+        &std::env::var("FIREBLOCKS_SOURCE_VAULT_ACCOUNT").expect("fireblocks source vault account not set"),
         chain_id,
     )?;
 
@@ -62,3 +61,10 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
  ```
+
+ ## Sandbox environment
+
+Fireblocks sandbox api is available at `https://sandbox-api.fireblocks.io` in contrast with test and production api available at `https://api.fireblocks.io`. By default `FireblocksSigner` connects to production url. You can override this behaviour (i.e. to connect to sandbox) by setting env var:
+```
+export FIREBLOCKS_API_URL_OVERRIDE="https://sandbox-api.fireblocks.io"
+```

--- a/src/api.rs
+++ b/src/api.rs
@@ -12,7 +12,7 @@ use jsonwebtoken::EncodingKey;
 use reqwest::{Client, RequestBuilder};
 use serde::{de::DeserializeOwned, Serialize};
 
-const FIREBLOCKS_API: &str = "https://sandbox-api.fireblocks.io";
+const FIREBLOCKS_API: &str = "https://api.fireblocks.io";
 const VERSION: &str = "v1";
 
 #[derive(Debug, Clone)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -12,7 +12,7 @@ use jsonwebtoken::EncodingKey;
 use reqwest::{Client, RequestBuilder};
 use serde::{de::DeserializeOwned, Serialize};
 
-const FIREBLOCKS_API: &str = "https://api.fireblocks.io";
+const FIREBLOCKS_API: &str = "https://sandbox-api.fireblocks.io";
 const VERSION: &str = "v1";
 
 #[derive(Debug, Clone)]

--- a/src/api.rs
+++ b/src/api.rs
@@ -25,8 +25,12 @@ pub struct FireblocksClient {
 
 // This impl block contains the necessary API calls for interacting with Ethereum
 impl FireblocksClient {
-    pub fn new(key: EncodingKey, api_key: &str) -> Self {
-        Self::new_with_url(key, api_key, FIREBLOCKS_API)
+    pub fn new(key: EncodingKey, api_key: &str, api_url_override: Option<&str>) -> Self {
+        let api_url = match api_url_override {
+            Some(url) => url,
+            None => FIREBLOCKS_API
+        };
+        Self::new_with_url(key, api_key, api_url)
     }
 
     pub fn new_with_url(key: EncodingKey, api_key: &str, url: &str) -> Self {
@@ -132,6 +136,13 @@ impl FireblocksClient {
 mod tests {
     use super::*;
 
+    // this section implements method useful in tests
+    impl FireblocksClient {
+        pub fn url(&self) -> &str {
+            &self.url
+        }
+    }
+
     #[tokio::test]
     async fn v1_api() {
         let fireblocks_key = std::env::var("FIREBLOCKS_API_SECRET_PATH").unwrap();
@@ -139,7 +150,9 @@ mod tests {
 
         let rsa_pem = std::fs::read(fireblocks_key).unwrap();
         let key = EncodingKey::from_rsa_pem(&rsa_pem[..]).unwrap();
-        let client = FireblocksClient::new(key, &api_key);
+        let client = FireblocksClient::new(key, &api_key, None);
+
+        assert_eq!(client.url(), FIREBLOCKS_API);
 
         let _res = client.vaults().await.unwrap();
         let _res = client.vault("0").await.unwrap();
@@ -156,4 +169,6 @@ mod tests {
             .await
             .unwrap();
     }
+
+    // test api url
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,15 @@ impl AsRef<FireblocksClient> for FireblocksSigner {
 impl FireblocksSigner {
     /// Instantiates a FireblocksSigner with the provided config
     pub async fn new(cfg: Config) -> Self {
-        let fireblocks = FireblocksClient::new(cfg.key, &cfg.api_key);
+        let local;
+        let api_url_override = match std::env::var("FIREBLOCKS_API_URL_OVERRIDE") {
+            Ok(string) => {
+                local = string;
+                Some(local.as_str())
+            },
+            Err(_) => None
+        };
+        let fireblocks = FireblocksClient::new(cfg.key, &cfg.api_key, api_url_override);
         let asset_id = match cfg.chain_id {
             1 => "ETH",
             3 => "ETH_TEST",


### PR DESCRIPTION
Currently an api URL is hardcoded and does not allow override. Sandbox accounts though connect via a different api URL. In this PR I add a possibility to override an api URL by setting env var:
```
export FIREBLOCKS_API_URL_OVERRIDE="https://sandbox-api.fireblocks.io"
```
which makes it possible to use this SDK also with sandbox accounts.